### PR TITLE
feat: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This file manages code responsibility in this project.
+# For reference, each line consists of a glob match pattern followed by a user selector.
+
+# Users that match the given selection pattern will be automatically requested for a review
+# when a pull request is made which modifies any of the specified files.
+
+# Global owners.
+* @liangricky7
+
+# Frontend
+/frontend/ @liangricky7 @DamienVesper


### PR DESCRIPTION
 - Adds CODEOWNERS.
 
 @liangricky7 Merge to main, then update, at the very least, `frontend` with this commit (you can just merge main into frontend, not the cleanest, but is still fine).
 
 Eventually this needs to go to ALL branches. Any base branch that does not have a CODEOWNERS will restrict merge PR ability to repo admins (either via specific repo access or org perms) ONLY.